### PR TITLE
chore: registre Satis -> packagist.df.cfcopies.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Simple static Composer repository generator.
 
-[CFC Packagist repository](https://packagist.cfc.to/)
+[CFC Packagist repository](https://packagist.df.cfcopies.com/)
 
 ## Run from source
 

--- a/satis.json
+++ b/satis.json
@@ -1,6 +1,6 @@
 {
     "name": "cfc/repositories",
-    "homepage": "https://packagist.cfc.to/",
+    "homepage": "https://packagist.df.cfcopies.com/",
     "repositories": [
         {
             "type": "vcs",


### PR DESCRIPTION
## Objet

`satis.json` déclare encore `homepage: https://packagist.cfc.to/`. Le domaine `cfc.to` n'est pas
renouvelé et expire début septembre : le `homepage` de Satis sert à construire les URLs du
registre, donc un rebuild figerait des URLs mortes dans l'index Composer.

Le domaine des GitHub Pages du repo est déjà `packagist.df.cfcopies.com` (CNAME vers
`cfc-to.github.io`, certificat valide, `packages.json` en 200). `packagist.cfc.to` renvoie 404.

Les 4 `composer.json` consommateurs (monark, chorus, directory, codex) pointent déjà tous sur
`https://packagist.df.cfcopies.com`. Cette PR aligne la dernière référence.

## Contenu

| Fichier | Avant | Après |
|---|---|---|
| `satis.json` | `https://packagist.cfc.to/` | `https://packagist.df.cfcopies.com/` |
| `README.md` | lien vers `packagist.cfc.to` | lien vers `packagist.df.cfcopies.com` |

## Effet du merge

Le workflow `Build static satis page` se déclenche sur push sur `main` : merger relance donc un
build et un redéploiement de `gh-pages`. C'est le comportement voulu.

## ⚠️ À part, mais bien plus important

Le registre publié renvoie aujourd'hui **0 version pour tous les paquets** testés
(`cfc/cfc-theme`, `cfc/chorus-php-client`, `cfc/codex-client`, `cfc/directory-client` :
`{"packages":{"...":[]}}`), alors que les builds passent en succès (dernier le 2026-08-01).

C'est le symptôme d'un `COMPOSER_TOKEN` qui n'a plus accès aux dépôts privés : Satis construit
un index vide sans échouer. **Cette PR ne corrige pas ce point** et ne l'aggrave pas non plus,
puisque les rebuilds ont déjà lieu régulièrement. À traiter séparément.
